### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/inc/customizer/js/control-range-slider.js
+++ b/inc/customizer/js/control-range-slider.js
@@ -17,14 +17,14 @@
         var suffix = $(this).prev().attr('suffix')
           ? $(this).prev().attr('suffix')
           : ''
-        $(this).html(value + suffix)
+        $(this).text(value + suffix)
       })
 
       range.on('input', function () {
         var suffix = $(this).attr('suffix') ? $(this).attr('suffix') : ''
         $(this)
           .next(value)
-          .html(this.value + suffix)
+          .text(this.value + suffix)
       })
     })
   }


### PR DESCRIPTION
Fixes [https://github.com/tuanductran/news-publication/security/code-scanning/1](https://github.com/tuanductran/news-publication/security/code-scanning/1)

To fix the problem, we need to ensure that any text derived from the DOM attributes is properly escaped before being inserted into the HTML. This can be achieved by using a text node or a library function that handles escaping.

- Use `textContent` instead of `innerHTML` to set the text content of the element, which ensures that any HTML special characters are properly escaped.
- Specifically, replace the `$(this).html(value + suffix)` with `$(this).text(value + suffix)` to prevent the interpretation of the text as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
